### PR TITLE
Revert "dependabot: bump java-telegram-bot-api from 6.2.0 to 6.6.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
       <dependency>
         <groupId>com.github.pengrad</groupId>
         <artifactId>java-telegram-bot-api</artifactId>
-        <version>6.6.1</version>
+        <version>6.2.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This reverts commit 2c76393535d96ee5d28908b09e05118abf7f7e17.